### PR TITLE
fix urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ C64 hackers and Assembly lovers!
 A code-storage facility, The re-source for Commodore-64 and 6502 programmers.
 * [All About Your 64 Online Help](http://unusedino.de/ec64/technical/aay/c64/index.htm)  
 By Ninja/The Dreams - (1995 - 2005)
-* [Commodore Languages List](http://www.npsnet.com/danf/cbm/languages.html)  
-Programming languages available for Commodore 8-bit computers.
 * [Operating System and Compiler Collection](http://www.lyonlabs.org/commodore/onrequest/collections.html)  
 Wide range of compilers and OSes for C64
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,9 @@
 Commodore 64 related links such as C64 tools for Mac/Linux/PC,
 demoscene related stuff, coding tools, C64 utilities etc...
 
-
-## Commodore 64 Utilities
-
-* [http://c64warez.com/](http://c64warez.com/)  
-Commodore 64/128 related tools.
-
-
 ## Portals
 
-* [DLH's Commodore Archive](http://www.bombjack.org/commodore/)  
+* [DLH's Commodore Archive](https://commodore.bombjack.org/)  
 Book, Magazines, Manuals, Disk Images, C16/+4, C128, VIC related...
 
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Wide range of compilers and OSes for C64
 
 
 ## Mac OS X Tools
+* [Virtual C64](https://dirkwhoffmann.github.io/virtualc64)  
+Mac C64 emulator.
 
 * [MacVICE](http://lallafa.de/blog/c64-projects/macvice/)  
-Best C64 emulator VICE’s OS X (*various compilers*) builds.
+C64 emulator VICE’s OS X (*various compilers*) builds.
 
 ## PC (Windows) Tools
 


### PR DESCRIPTION
removed c64warez.com which is dead fixes #1  …
updated DHL url with working url
removed Commodore Languages List as url is dead